### PR TITLE
Go Playground/validator 扩展 PR 提案分析

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _testmain.go
 *.txt
 cover.html
 README.html
+.idea
+.vscode

--- a/errors.go
+++ b/errors.go
@@ -160,8 +160,16 @@ type FieldError interface {
 	Error() string
 }
 
+type TopFieldError interface {
+	FieldError
+
+	// Top returns the actual field's parent value in case needed for creating custom the error
+	Top() reflect.Value
+}
+
 // compile time interface checks
 var _ FieldError = new(fieldError)
+var _ TopFieldError = new(fieldError)
 var _ error = new(fieldError)
 
 // fieldError contains a single field's validation error along
@@ -179,6 +187,7 @@ type fieldError struct {
 	param          string
 	kind           reflect.Kind
 	typ            reflect.Type
+	top            reflect.Value
 }
 
 // Tag returns the validation tag that failed.
@@ -272,4 +281,10 @@ func (fe *fieldError) Translate(ut ut.Translator) string {
 	}
 
 	return fn(ut, fe)
+}
+
+// Top returns the actual field's parent value in case needed for creating custom the error
+// message
+func (fe *fieldError) Top() reflect.Value {
+	return fe.top
 }

--- a/struct_level.go
+++ b/struct_level.go
@@ -135,6 +135,7 @@ func (v *validate) ReportError(field interface{}, fieldName, structFieldName, ta
 				structfieldLen: uint8(len(structFieldName)),
 				param:          param,
 				kind:           kind,
+				top:            v.top,
 			},
 		)
 		return
@@ -153,6 +154,7 @@ func (v *validate) ReportError(field interface{}, fieldName, structFieldName, ta
 			param:          param,
 			kind:           kind,
 			typ:            fv.Type(),
+			top:            v.top,
 		},
 	)
 }

--- a/validator.go
+++ b/validator.go
@@ -129,6 +129,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 						structfieldLen: uint8(len(cf.name)),
 						param:          ct.param,
 						kind:           kind,
+						top:            v.top,
 					},
 				)
 				return
@@ -154,6 +155,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 						param:          ct.param,
 						kind:           kind,
 						typ:            current.Type(),
+						top:            v.top,
 					},
 				)
 				return
@@ -199,6 +201,7 @@ func (v *validate) traverseField(ctx context.Context, parent reflect.Value, curr
 								param:          ct.param,
 								kind:           kind,
 								typ:            typ,
+								top:            v.top,
 							},
 						)
 						return
@@ -413,6 +416,7 @@ OUTER:
 								param:          ct.param,
 								kind:           kind,
 								typ:            typ,
+								top:            v.top,
 							},
 						)
 
@@ -433,6 +437,7 @@ OUTER:
 								param:          ct.param,
 								kind:           kind,
 								typ:            typ,
+								top:            v.top,
 							},
 						)
 					}
@@ -474,6 +479,7 @@ OUTER:
 						param:          ct.param,
 						kind:           kind,
 						typ:            typ,
+						top:            v.top,
 					},
 				)
 

--- a/validator_test.go
+++ b/validator_test.go
@@ -351,7 +351,7 @@ func TestStructLevelInvalidError(t *testing.T) {
 	validate.RegisterStructValidation(StructLevelInvalidError, StructLevelInvalidErr{})
 
 	var test StructLevelInvalidErr
-
+	val := reflect.ValueOf(test)
 	err := validate.Struct(test)
 	NotEqual(t, err, nil)
 
@@ -367,6 +367,10 @@ func TestStructLevelInvalidError(t *testing.T) {
 	Equal(t, fe.ActualTag(), "required")
 	Equal(t, fe.Kind(), reflect.Invalid)
 	Equal(t, fe.Type(), reflect.TypeOf(nil))
+	top, ok := fe.(TopFieldError)
+	Equal(t, ok, true)
+	Equal(t, top.Top().Kind(), val.Kind())
+	Equal(t, top.Top().Type().Name(), val.Type().Name())
 }
 
 func TestNameNamespace(t *testing.T) {


### PR DESCRIPTION
1. 当前情况分析
go-playground/validator 是一个广泛使用的 Go 数据验证库。目前的 FieldError 接口提供了字段级别的错误信息，但没有直接提供访问父级结构的机制。

2. PR 提案技术评估
您的提案是添加 TopFieldError 接口，扩展 FieldError 添加 Top() 方法来返回校验字段对应的父级反射值。这将：

保持向后兼容性（不会破坏现有实现）
为更高级的校验功能（如访问父结构标签）铺路
提升库的灵活性
3. 实现建议
建议采用以下实现方案：

<GO>
// TopFieldError 扩展接口
type TopFieldError interface {
    FieldError
    // Top 返回当前校验字段的父级反射值
    Top() reflect.Value
}
实现要点：
应该在 validator/v10/errors.go 中添加新接口定义
在现有的 fieldError 结构中添加父级反射值的存储字段
修改验证过程中填充父级反射值的逻辑
添加相应的测试用例
4. 用例场景
这个改动将支持如下使用场景：

<GO>
type User struct {
    Name string `validate:"required"`
    Address struct {
        Street string `json:"street" validate:"required"`
    }
}
err := validate.Struct(user)
if err != nil {
    for _, fieldErr := range err.(validator.ValidationErrors) {
        if topErr, ok := fieldErr.(validator.TopFieldError); ok {
            parent := topErr.Top()
            // 现在可以获取父结构的元信息
            fmt.Println("Parent type:", parent.Type())
        }
    }
}
5. 需要考虑的问题
性能影响：存储父级反射值会增加少量内存开销
兼容性：需要确保不破坏现有功能
文档更新：需要更新库文档说明新功能
测试覆盖率：需要为新增功能添加充分测试
6. PR 提交建议
先创建一个 issue 讨论这个功能提案
保持 PR 范围专注（仅实现 TopFieldError 接口）
提供清晰的文档说明和用例
确保所有测试通过
遵循项目的贡献指南